### PR TITLE
Update config to support BrowserStack

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -11,9 +11,27 @@ export const config: RemoteOptions = {
       },
     ],
   ],
-  capabilities: {
-    browserName: "chrome",
+  commonCapabilities: {
+    build: "Mobile Device Test Examples",
+    project: "PayPal SDK",
   },
+  capabilities: [
+    {
+      // @ts-expect-error os key is invalid
+      os: "Windows",
+      os_version: "10",
+      browserName: "Chrome",
+      browser_version: "latest",
+    },
+    {
+      // @ts-expect-error browserName key is invalid
+      browserName: "android",
+      os_version: "10.0",
+      device: "Samsung Galaxy S20",
+      real_mobile: "true",
+    },
+  ],
+
   waitforTimeout: 10000,
   logLevel: "silent",
 };


### PR DESCRIPTION
This PR add support for using BrowserStack. There are currently two problems:

1. There are type errors with the `capabilities` array values.
2. BrowserStack is not using the browsers defined in the capabilities list.